### PR TITLE
お知らせの詳細画面を表示（遷移）する機能を実装

### DIFF
--- a/src/features/news/components/NewsDetailForAdmin.tsx
+++ b/src/features/news/components/NewsDetailForAdmin.tsx
@@ -3,6 +3,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import MultiColumnPageTitle from "@/components/page-title/MultiColumnPageTitle";
 import { useApiRequest } from "@/hooks/useApiRequest";
+import { NewsDto } from "../types";
 
 interface NewsDetailProps {
   newsId?: string;
@@ -13,45 +14,49 @@ interface NewsDetailProps {
 export default function NewsDetail(props: NewsDetailProps) {
   const router = useRouter();
 
+  // URLパラメータからnewsIdを取得する
+  const newsId = useParams().newsId;
+
   // newsの削除を取得するAPI
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
 
   // 仮の初期データ（後でAPI連携可能）
-  const initialNewsMap: Record<
-    string,
-    { date: string; title: string; content: string }
-  > = {
-    "1": {
-      date: "2025-01-01",
-      title: "大事なお知らせ①",
-      content:
-        "新年あけましておめでとうございます。今年もよろしくお願いします。",
-    },
-    "2": {
-      date: "2025-01-02",
-      title: "大事なお知らせ②",
-      content: "新機能のリリース予定についてのお知らせです。",
-    },
-    "3": {
-      date: "2025-01-03",
-      title: "大事なお知らせ③",
-      content:
-        "メンテナンスのお知らせです。1月5日にサーバーメンテナンスを行います。",
-    },
-  };
+  //   const initialNewsMap: Record<
+  //     string,
+  //     { date: string; title: string; content: string }
+  //   > = {
+  //     "1": {
+  //       date: "2025-01-01",
+  //       title: "大事なお知らせ①",
+  //       content:
+  //         "新年あけましておめでとうございます。今年もよろしくお願いします。",
+  //     },
+  //     "2": {
+  //       date: "2025-01-02",
+  //       title: "大事なお知らせ②",
+  //       content: "新機能のリリース予定についてのお知らせです。",
+  //     },
+  //     "3": {
+  //       date: "2025-01-03",
+  //       title: "大事なお知らせ③",
+  //       content:
+  //         "メンテナンスのお知らせです。1月5日にサーバーメンテナンスを行います。",
+  //     },
+  //   };
 
+  //   画面に表示するstate
   const [date, setDate] = useState("");
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
 
-  const news = initialNewsMap[props.newsId as string];
-  useEffect(() => {
-    if (news) {
-      setDate(news.date);
-      setTitle(news.title);
-      setContent(news.content);
-    }
-  }, [news]);
+  //   const news = initialNewsMap[props.newsId as string];
+  //   useEffect(() => {
+  //     if (news) {
+  //       setDate(news.date);
+  //       setTitle(news.title);
+  //       setContent(news.content);
+  //     }
+  //   }, [news]);
 
   const handleUpdate = () => {
     // 本来はAPIを呼んで保存する処理
@@ -65,7 +70,38 @@ export default function NewsDetail(props: NewsDetailProps) {
     }
   };
 
-  if (!props.isNew && !news) {
+  // お知らせ取得API
+  const {
+    executeApi: executeFindNewsByIdApi,
+    isLoading: isLoadingFindNewaByIdApi,
+    response: responseOfFindNewsByIdApi,
+    isError: isErrorFindNewsByIdApi,
+  } = useApiRequest();
+
+  //   レスポンスを取得？？
+  useEffect(() => {
+    if (newsId) {
+      console.log("API呼び出しを開始:", newsId);
+      executeFindNewsByIdApi(`http://localhost:8080/api/news/${newsId}`, "GET");
+    }
+  }, [executeFindNewsByIdApi, newsId]);
+
+  //   レスポンスからそれぞれのデータをセットする
+  useEffect(() => {
+    if (!responseOfFindNewsByIdApi) {
+      console.log("レスポンスがありませんでした");
+      return;
+    }
+    responseOfFindNewsByIdApi.json().then((newsDto: NewsDto) => {
+      console.log("json 変換成功", newsDto);
+      setTitle(newsDto.title);
+      setContent(newsDto.content);
+      setDate(newsDto.createdAt);
+      console.log(newsDto.title);
+    });
+  }, [responseOfFindNewsByIdApi, newsId]);
+
+  if (!props.isNew && !responseOfFindNewsByIdApi) {
     return (
       <>
         <MultiColumnPageTitle title="お知らせ詳細" />

--- a/src/features/news/components/NewsDetailForAdmin.tsx
+++ b/src/features/news/components/NewsDetailForAdmin.tsx
@@ -20,43 +20,10 @@ export default function NewsDetail(props: NewsDetailProps) {
   // newsの削除を取得するAPI
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
 
-  // 仮の初期データ（後でAPI連携可能）
-  //   const initialNewsMap: Record<
-  //     string,
-  //     { date: string; title: string; content: string }
-  //   > = {
-  //     "1": {
-  //       date: "2025-01-01",
-  //       title: "大事なお知らせ①",
-  //       content:
-  //         "新年あけましておめでとうございます。今年もよろしくお願いします。",
-  //     },
-  //     "2": {
-  //       date: "2025-01-02",
-  //       title: "大事なお知らせ②",
-  //       content: "新機能のリリース予定についてのお知らせです。",
-  //     },
-  //     "3": {
-  //       date: "2025-01-03",
-  //       title: "大事なお知らせ③",
-  //       content:
-  //         "メンテナンスのお知らせです。1月5日にサーバーメンテナンスを行います。",
-  //     },
-  //   };
-
-  //   画面に表示するstate
+  // 画面に表示するstate
   const [date, setDate] = useState("");
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-
-  //   const news = initialNewsMap[props.newsId as string];
-  //   useEffect(() => {
-  //     if (news) {
-  //       setDate(news.date);
-  //       setTitle(news.title);
-  //       setContent(news.content);
-  //     }
-  //   }, [news]);
 
   const handleUpdate = () => {
     // 本来はAPIを呼んで保存する処理
@@ -78,7 +45,7 @@ export default function NewsDetail(props: NewsDetailProps) {
     isError: isErrorFindNewsByIdApi,
   } = useApiRequest();
 
-  //   レスポンスを取得？？
+  // レスポンスを取得？？
   useEffect(() => {
     if (newsId) {
       console.log("API呼び出しを開始:", newsId);
@@ -86,7 +53,7 @@ export default function NewsDetail(props: NewsDetailProps) {
     }
   }, [executeFindNewsByIdApi, newsId]);
 
-  //   レスポンスからそれぞれのデータをセットする
+  // レスポンスからそれぞれのデータをセットする
   useEffect(() => {
     if (!responseOfFindNewsByIdApi) {
       console.log("レスポンスがありませんでした");

--- a/src/features/news/components/NewsListForAdmin.tsx
+++ b/src/features/news/components/NewsListForAdmin.tsx
@@ -29,6 +29,11 @@ export default function NewsList() {
     response: responseOfFindNewsApi,
   } = useApiRequest();
 
+  //お知らせ詳細画面遷移
+  const toNewsDetailView = (id: String) => {
+    router.push(`/admin/news/${id}/edit`);
+  };
+
   // お知らせ削除API
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
 

--- a/src/features/news/components/NewsListForAdmin.tsx
+++ b/src/features/news/components/NewsListForAdmin.tsx
@@ -29,15 +29,10 @@ export default function NewsList() {
     response: responseOfFindNewsApi,
   } = useApiRequest();
 
-//   //お知らせ詳細画面遷移
-//   const toNewsDetailView = (id: String) => {
-//     router.push(`/admin/news/${id}/edit`);
-//   };
-
   // お知らせ削除API
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
 
-    //お知らせ詳細画面遷移
+  // お知らせ詳細画面遷移
   const toNewsDetailPage = (newsId: string) => {
     router.push("/admin/news/" + newsId + "/edit");
   };

--- a/src/features/news/components/NewsListForAdmin.tsx
+++ b/src/features/news/components/NewsListForAdmin.tsx
@@ -29,14 +29,15 @@ export default function NewsList() {
     response: responseOfFindNewsApi,
   } = useApiRequest();
 
-  //お知らせ詳細画面遷移
-  const toNewsDetailView = (id: String) => {
-    router.push(`/admin/news/${id}/edit`);
-  };
+//   //お知らせ詳細画面遷移
+//   const toNewsDetailView = (id: String) => {
+//     router.push(`/admin/news/${id}/edit`);
+//   };
 
   // お知らせ削除API
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
 
+    //お知らせ詳細画面遷移
   const toNewsDetailPage = (newsId: string) => {
     router.push("/admin/news/" + newsId + "/edit");
   };


### PR DESCRIPTION
【修正内容の概要】
お知らせ一覧画面から、対象のお知らせをクリックすると詳細画面を表示する機能を実装しました。

【特に見てほしいところや不安なところ】
「お知らせ詳細表示機能」というものが詳細画面へ遷移する実装で間違いなかったでしょうか？
※削除機能を実装するにあたり、詳細画面の表示は必要だったので実装しましたが、思っていたタスクと異なった場合はご指摘ください。
記述の部分に関しては特に困ったところはありませんでした。

【共有事項】
特にありません