### PR TITLE
詳細画面からの削除ボタン→実行処理実装

### DIFF
--- a/src/features/news/components/NewsDetailForAdmin.tsx
+++ b/src/features/news/components/NewsDetailForAdmin.tsx
@@ -15,7 +15,7 @@ export default function NewsDetail(props: NewsDetailProps) {
   const router = useRouter();
 
   // URLパラメータからnewsIdを取得する
-  const newsId = useParams().newsId;
+  const newsId = props.newsId;
 
   // newsの削除を取得するAPI
   const { executeApi: executeDeleteNewsApi } = useApiRequest();
@@ -30,9 +30,14 @@ export default function NewsDetail(props: NewsDetailProps) {
     router.push("/admin/news");
   };
 
-  const handleDelete = async () => {
+  const handleDelete = async (e: React.MouseEvent) => {
     if (confirm("本当に削除しますか？")) {
       // 削除API呼び出し予定
+      e.stopPropagation();
+      await executeDeleteNewsApi(
+        `http://localhost:8080/api/news/${newsId}`,
+        "DELETE"
+      );
       router.push("/admin/news");
     }
   };
@@ -45,7 +50,7 @@ export default function NewsDetail(props: NewsDetailProps) {
     isError: isErrorFindNewsByIdApi,
   } = useApiRequest();
 
-  // レスポンスを取得？？
+  // バックエンドサイドへリクエストを送信する
   useEffect(() => {
     if (newsId) {
       console.log("API呼び出しを開始:", newsId);


### PR DESCRIPTION
【修正内容の概要】
お知らせ詳細画面が追加できましたので、詳細画面より削除ボタンを押して、削除が実行されるように実装しました。

【特に見てほしいところや不安なところ】
削除実行後にお知らせ一覧画面に遷移しているので、詳細画面ではレスポンス処理
await executeFindNewsApi("http://localhost:8080/api/news", "GET");は記述しておりません。

NewsListNewsListForAdminの下記で取得できそうだと考えたのですが、相違ないでしょうか？
useEffect(() => {
    const fetchData = async () => {
      const findNewsApiResponse = await executeFindNewsApi(
        "http://localhost:8080/api/news",
        "GET"
      );
      findNewsApiResponse?.json().then((newsPageDto: NewsPageDto) => {
        setNewsDtos(newsPageDto.newsDtos);
      });
    };
    fetchData();
  }, [executeFindNewsApi]);


【共有事項】
特になし